### PR TITLE
Data connector crash fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     deobfCompile 'baubles:Baubles:1.12:1.5.2'
 
     compileOnly "org.squiddev:cc-tweaked-1.12.2:1.89.2"
-    compileOnly "opencomputers:OpenComputers:MC1.12.2:1.7.2.67"
+    compileOnly "li.cil.oc:OpenComputers:MC1.12.2-1.7.5.221:api"
 
     compileOnly "curse.maven:immersive-petroleum-268250:2544919"
     compileOnly "curse.maven:immersive-posts-314645:2951672"

--- a/src/main/java/pl/pabilo8/immersiveintelligence/common/blocks/metal/TileEntityDataConnector.java
+++ b/src/main/java/pl/pabilo8/immersiveintelligence/common/blocks/metal/TileEntityDataConnector.java
@@ -306,6 +306,7 @@ public class TileEntityDataConnector extends TileEntityImmersiveConnectable impl
 
 	@Nullable
 	@Override
+	@Optional.Method(modid = "computercraft")
 	public IPeripheral getPeripheral(@Nonnull EnumFacing facing)
 	{
 		return facing==this.facing?ComputerCraftHelper.createConnectorPeripheral(this): null;


### PR DESCRIPTION
Switches to a newer OpenComputers API and makes the ComputerCraft compat method optional
Fixes #216